### PR TITLE
fix: move lodash to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "esbuild": "^0.8.23",
     "find-yarn-workspace-root": "^2.0.0",
     "pkg-dir": "^5.0.0",
-    "yargs": "^16.2.0"
+    "yargs": "^16.2.0",
+    "lodash": "^4.17.20",
   },
   "devDependencies": {
     "@gadgetinc/eslint-config": "^0.1.1",
@@ -43,8 +44,7 @@
     "@types/lodash": "^4.14.167",
     "@types/node": "^14.14.14",
     "@types/yargs": "^15.0.12",
-    "eslint": "^7.15.0",
-    "lodash": "^4.17.20",
+    "eslint": "^7.15.0",    
     "prettier": "^2.2.1",
     "typescript": "^4.1.3"
   }


### PR DESCRIPTION
the missing `lodash` dependency causes an error immediately upon usage.