### PR TITLE
Apple Silicon support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 pkg
 .envrc.local
 test/supervise/run-scratch.ts
+.direnv

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,7 @@
     (flake-utils.lib.eachSystem [
       "x86_64-linux"
       "x86_64-darwin"
+      "aarch64-darwin"
     ]
       (system: nixpkgs.lib.fix (flake:
         let


### PR DESCRIPTION
This PR allows flakes to be installed on Apple Silicon. It also adds the `.direnv` folder to `.gitignore`. 