### PR TITLE
Use @cspotcode/source-map-support instead of native --enable-source-maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "prerelease": "gitpkg publish"
   },
   "dependencies": {
+    "@cspotcode/source-map-support": "^0.7.0",
     "chokidar": "^3.4.3",
     "esbuild": "^0.13.14",
     "find-root": "^1.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,12 +125,7 @@ const startIPCServer = async (socketPath: string, project: Project) => {
 };
 
 const childProcessArgs = () => {
-  return [
-    "-r",
-    path.join(__dirname, "child-process-registration.js"),
-    "-r",
-    path.join(__dirname, "../node_modules/@cspotcode/source-map-support/register"),
-  ];
+  return ["-r", path.join(__dirname, "child-process-registration.js"), "-r", require.resolve("@cspotcode/source-map-support/register")];
 };
 
 export const esbuildDev = async (options: RunOptions) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,12 @@ const startIPCServer = async (socketPath: string, project: Project) => {
 };
 
 const childProcessArgs = () => {
-  return ["-r", path.join(__dirname, "child-process-registration.js"), "--enable-source-maps"];
+  return [
+    "-r",
+    path.join(__dirname, "child-process-registration.js"),
+    "-r",
+    path.join(__dirname, "../node_modules/@cspotcode/source-map-support/register"),
+  ];
 };
 
 export const esbuildDev = async (options: RunOptions) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,18 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@cspotcode/source-map-consumer@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz#33bf4b7b39c178821606f669bbc447a6a629786b"
+  integrity sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==
+
+"@cspotcode/source-map-support@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz#4789840aa859e46d2f3173727ab707c66bf344f5"
+  integrity sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==
+  dependencies:
+    "@cspotcode/source-map-consumer" "0.8.0"
+
 "@eslint/eslintrc@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.0.tgz#99cc0a0584d72f1df38b900fb062ba995f395547"
@@ -398,11 +410,6 @@ braces@^3.0.1, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
-
-buffer-from@^1.0.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
-  integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
 buffer@^5.5.0:
   version "5.7.1"
@@ -2318,19 +2325,6 @@ slice-ansi@^4.0.0:
     ansi-styles "^4.0.0"
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
-
-source-map-support@^0.5.21:
-  version "0.5.21"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
-  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
-  dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
-
-source-map@^0.6.0:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 spdx-correct@^3.0.0:
   version "3.1.1"


### PR DESCRIPTION
#21 introduced a pretty significant regression. Using the `--enable-source-maps` Node flag slowed down the code by a factor of ~700% to 800%.

The original hypothesis was that loading inline sourcemaps was slow, and that external ones would've been faster. I successfully tried generating and loading external sourcemaps but the results were the same. This led me to test other hypothesis to narrow down the problem. 

As you can see in the graph below, Node will be a lot slower if the sourcemaps are enabled, AND generated by the compiler. It will be somewhat faster if sourcemaps are enabled but not generated. Finally, if the sourcemaps are disabled, it will perform at a reasonable speed.

|--enable-source-maps | Compiler { sourcemaps } | time
|---------------------|-------------------------|-----
|       yes           |     external     | 38.9s
|       yes           |     false               | 24.5s
|       no            |     N/A                 | 3.8s

@airhorns suggested that we instead try with the `@cspotcode/source-map-support` package. 

This package is much faster than native. I'm hesitant to give actual time comparisons because it suffers from high variability, but I see results in the 4.5 - 10s range, clustered around 6s. 

This is to say that there _is_ a cost to using sourcemaps. Nonetheless, I think we should enable them because of the benefits to debugging. If the cost is too high, we can absolutely introduce an opt-out switch for those who prefer speed over features.